### PR TITLE
hid the "read more" text on the home page from screenreaders

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ use-site-title: true
         {{ post.excerpt | truncatewords: site.excerpt_length }}
         {% assign excerpt_word_count = post.excerpt | number_of_words %}
         {% if post.content != post.excerpt or excerpt_word_count > site.excerpt_length %}
-          <a href="{{ post.url | prepend: site.baseurl }}" class="post-read-more">[Read&nbsp;More]</a>
+          <a href="{{ post.url | prepend: site.baseurl }}" class="post-read-more" aria-hidden="true">[Read&nbsp;More]</a>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
a small tweak to the index.html read more links to address #6 